### PR TITLE
Add header to device port issue template

### DIFF
--- a/ISSUE_TEMPLATE/device-port.md
+++ b/ISSUE_TEMPLATE/device-port.md
@@ -1,3 +1,8 @@
+---
+name: Device port
+about: Template for tracking progress of device ports
+---
+
 Tree: <!-- halium-5.1 or halium-7.1 -->
 
 - [ ] Create manifest <!-- Link to the manifest, contained in a pull request to https://github.com/Halium/halium-devices -->


### PR DESCRIPTION
As suggested by @z3ntu this adds a header to the issue template. This makes it
possible to select the issue template when opening a new issue.